### PR TITLE
Add vendor composer autoload to bootstrap

### DIFF
--- a/guzzle/test/bootstrap.php
+++ b/guzzle/test/bootstrap.php
@@ -1,3 +1,3 @@
 <?php
-
+require ('../vendor/autoload.php');
 \VCR\VCR::configure()->setCassettePath('test/fixtures');


### PR DESCRIPTION
When the sample is installed, the composer class loader is not included.
